### PR TITLE
Drop redundant apt-get switches, -qq implies -y

### DIFF
--- a/code/4/Dockerfile_template
+++ b/code/4/Dockerfile_template
@@ -1,4 +1,4 @@
 FROM ubuntu:16.04
 MAINTAINER James Turnbull "james@example.com"
 ENV REFRESHED_AT 2016-06-01
-RUN apt-get -qqy update
+RUN apt-get -qq update

--- a/code/5/jenkins/Dockerfile
+++ b/code/5/jenkins/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER james@example.com
 ENV REFRESHED_AT 2016-06-01
 
 USER root
-RUN apt-get -qqy update && apt-get install -qqy sudo
+RUN apt-get -qq update && apt-get install -qq sudo
 RUN echo "jenkins ALL=NOPASSWD: ALL" >> /etc/sudoers
 RUN wget http://get.docker.com/builds/Linux/x86_64/docker-latest.tgz
 RUN tar -xvzf docker-latest.tgz

--- a/code/5/sample/Dockerfile
+++ b/code/5/sample/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull "james@example.com"
 ENV REFRESHED_AT 2014-06-01
 
-RUN apt-get -yqq update && apt-get -yqq install nginx
+RUN apt-get -qq update && apt-get -qq install nginx
 
 RUN mkdir -p /var/www/html/website
 ADD nginx/global.conf /etc/nginx/conf.d/

--- a/code/5/sinatra/redis/Dockerfile
+++ b/code/5/sinatra/redis/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull "james@example.com"
 ENV REFRESHED_AT 2014-06-01
 
-RUN apt-get -yqq update && apt-get -yqq install redis-server redis-tools
+RUN apt-get -qq update && apt-get -qq install redis-server redis-tools
 
 EXPOSE 6379
 

--- a/code/5/sinatra/webapp/Dockerfile
+++ b/code/5/sinatra/webapp/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull "james@example.com"
 ENV REFRESHED_AT 2014-06-01
 
-RUN apt-get -yqq update && apt-get -yqq install ruby ruby-dev build-essential redis-tools
+RUN apt-get -qq update && apt-get -qq install ruby ruby-dev build-essential redis-tools
 RUN gem install --no-rdoc --no-ri sinatra json redis
 
 RUN mkdir -p /opt/webapp

--- a/code/6/jekyll/apache/Dockerfile
+++ b/code/6/jekyll/apache/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04
 MAINTAINER James Turnbull <james@example.com>
 
-RUN apt-get -yqq update
-RUN apt-get -yqq install apache2
+RUN apt-get -qq update
+RUN apt-get -qq install apache2
 
 VOLUME [ "/var/www/html" ]
 WORKDIR /var/www/html

--- a/code/6/jekyll/jekyll/Dockerfile
+++ b/code/6/jekyll/jekyll/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull <james@example.com>
 ENV REFRESHED_AT 2016-06-01
 
-RUN apt-get -yqq update
-RUN apt-get -yqq install ruby ruby-dev build-essential nodejs
+RUN apt-get -qq update
+RUN apt-get -qq install ruby ruby-dev build-essential nodejs
 RUN gem install --no-rdoc --no-ri jekyll -v 2.5.3
 
 VOLUME /data

--- a/code/6/node/logstash/Dockerfile
+++ b/code/6/node/logstash/Dockerfile
@@ -2,12 +2,12 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull <james@example.com>
 ENV REFRESHED_AT 2016-06-01
 
-RUN apt-get -yqq update
-RUN apt-get -yqq install wget
+RUN apt-get -qq update
+RUN apt-get -qq install wget
 RUN wget -O - http://packages.elasticsearch.org/GPG-KEY-elasticsearch |  apt-key add -
 RUN echo 'deb http://packages.elasticsearch.org/logstash/1.5/debian stable main' > /etc/apt/sources.list.d/logstash.list
-RUN apt-get -yqq update
-RUN apt-get -yqq install logstash default-jdk
+RUN apt-get -qq update
+RUN apt-get -qq install logstash default-jdk
 
 ADD logstash.conf /etc/
 

--- a/code/6/node/nodejs/Dockerfile
+++ b/code/6/node/nodejs/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull <james@example.com>
 ENV REFRESHED_AT 2016-06-01
 
-RUN apt-get -yqq update
-RUN apt-get -yqq install nodejs npm
+RUN apt-get -qq update
+RUN apt-get -qq install nodejs npm
 RUN ln -s /usr/bin/nodejs /usr/bin/node
 RUN mkdir -p /var/log/nodeapp
 

--- a/code/6/node/redis_base/Dockerfile
+++ b/code/6/node/redis_base/Dockerfile
@@ -2,11 +2,11 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull <james@example.com>
 ENV REFRESHED_AT 2016-06-01
 
-RUN apt-get -yqq update
-RUN apt-get install -yqq software-properties-common python-software-properties
+RUN apt-get -qq update
+RUN apt-get install -qq software-properties-common python-software-properties
 RUN add-apt-repository ppa:chris-lea/redis-server
-RUN apt-get -yqq update
-RUN apt-get -yqq install redis-server redis-tools
+RUN apt-get -qq update
+RUN apt-get -qq install redis-server redis-tools
 
 VOLUME [ "/var/lib/redis", "/var/log/redis" ]
 

--- a/code/6/tomcat/fetcher/Dockerfile
+++ b/code/6/tomcat/fetcher/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull <james@example.com>
 ENV REFRESHED_AT 2016-06-01
 
-RUN apt-get -yqq update
-RUN apt-get -yqq install wget
+RUN apt-get -qq update
+RUN apt-get -qq install wget
 
 VOLUME [ "/var/lib/tomcat7/webapps/" ]
 WORKDIR /var/lib/tomcat7/webapps/

--- a/code/6/tomcat/tomcat7/Dockerfile
+++ b/code/6/tomcat/tomcat7/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull <james@example.com>
 ENV REFRESHED_AT 2016-06-01
 
-RUN apt-get -yqq update
-RUN apt-get -yqq install tomcat7 default-jdk
+RUN apt-get -qq update
+RUN apt-get -qq install tomcat7 default-jdk
 
 ENV CATALINA_HOME /usr/share/tomcat7
 ENV CATALINA_BASE /var/lib/tomcat7

--- a/code/7/consul/Dockerfile
+++ b/code/7/consul/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:14.04
 MAINTAINER James Turnbull <james@example.com>
 ENV REFRESHED_AT 2014-08-01
 
-RUN apt-get -qqy update
-RUN apt-get -qqy install curl unzip
+RUN apt-get -qq update
+RUN apt-get -qq install curl unzip
 
 ADD https://releases.hashicorp.com/consul/0.3.1/consul_0.3.1_linux_amd64.zip /tmp/consul.zip
 RUN cd /usr/sbin && unzip /tmp/consul.zip && chmod +x /usr/sbin/consul && rm /tmp/consul.zip

--- a/code/7/consul/consul/Dockerfile
+++ b/code/7/consul/consul/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull <james@example.com>
 ENV REFRESHED_AT 2016-06-01
 
-RUN apt-get -qqy update
-RUN apt-get -qqy install curl unzip
+RUN apt-get -qq update
+RUN apt-get -qq install curl unzip
 
 ADD https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip /tmp/consul.zip
 RUN cd /usr/sbin && unzip /tmp/consul.zip && chmod +x /usr/sbin/consul && rm /tmp/consul.zip

--- a/code/7/consul/distributed_app/Dockerfile
+++ b/code/7/consul/distributed_app/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull "james@example.com"
 ENV REFRESHED_AT 2016-06-01
 
-RUN apt-get -qqy update
-RUN apt-get -qqy install ruby-dev git libcurl4-openssl-dev curl build-essential python
+RUN apt-get -qq update
+RUN apt-get -qq install ruby-dev git libcurl4-openssl-dev curl build-essential python
 RUN gem install --no-ri --no-rdoc uwsgi sinatra
 
 RUN mkdir -p /opt/distributed_app

--- a/code/7/consul/distributed_client/Dockerfile
+++ b/code/7/consul/distributed_client/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull "james@example.com"
 ENV REFRESHED_AT 2016-06-01
 
-RUN apt-get -qqy update
-RUN apt-get -qqy install ruby ruby-dev build-essential
+RUN apt-get -qq update
+RUN apt-get -qq install ruby ruby-dev build-essential
 RUN gem install --no-ri --no-rdoc json
 
 RUN mkdir -p /opt/distributed_client


### PR DESCRIPTION
Hey there. I've noticed some redundant `apt-get` switches around the code and cleaned those up. Less noise is always better, IMHO.

From the [man page](https://linux.die.net/man/8/apt-get):

> Note that quiet level 2 implies -y

Thanks for the book, great stuff :-)