### PR TITLE
disable protected mode

### DIFF
--- a/code/6/node/redis_primary/Dockerfile
+++ b/code/6/node/redis_primary/Dockerfile
@@ -2,4 +2,4 @@ FROM jamtur01/redis
 MAINTAINER James Turnbull <james@example.com>
 ENV REFRESHED_AT 2016-06-01
 
-ENTRYPOINT [ "redis-server", "--logfile /var/log/redis/redis-server.log" ]
+ENTRYPOINT [ "redis-server", "--protected-mode no", "--logfile /var/log/redis/redis-server.log" ]


### PR DESCRIPTION
since version 3.2.0, when Redis is executed with the default configuration (binding all the interfaces) and without any password in order to access it, it enters a special mode called protected mode. In this mode Redis only replies to queries from the loopback interfaces.