### PR TITLE
Adding --fix-missing to redis base image Dockerfile

### DIFF
--- a/code/6/node/redis_base/Dockerfile
+++ b/code/6/node/redis_base/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER James Turnbull <james@example.com>
 ENV REFRESHED_AT 2016-06-01
 
-RUN apt-get -qq update
+RUN apt-get -qq update --fix-missing
 RUN apt-get install -qq software-properties-common python-software-properties
 RUN add-apt-repository ppa:chris-lea/redis-server
 RUN apt-get -qq update


### PR DESCRIPTION
Had some issues building the redis_base image - see error below.  I seem to have fixed this by adding --fix-missing to the first apt-get ....

Error message

 ---> Running in 8c89311e9cc3
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/u/unattended-upgrades/unattended-upgrades_0.90ubuntu0.5_all.deb  404  Not Found [IP: 91.189.88.152 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?