### PR TITLE
[FIX] don't confuse newcomers

### DIFF
--- a/code/7/composeapp/docker-compose.yml
+++ b/code/7/composeapp/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     ports:
      - "5000:5000"
     volumes:
-     - .:/composeapp
+     - .:/composeapp:ro
   redis:
     image: redis


### PR DESCRIPTION
docker-compose bind mounting is not meant to manipulate the source tree from within the docker container. Is it?